### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/talha0113/3504235c-4145-42ee-9d73-6f794f3258fd/c2ec2762-6a03-4766-903d-a7d583fc9d09/_apis/work/boardbadge/2869cebf-e0ac-4182-9b0c-0e4dab9014ec)](https://dev.azure.com/talha0113/3504235c-4145-42ee-9d73-6f794f3258fd/_boards/board/t/c2ec2762-6a03-4766-903d-a7d583fc9d09/Microsoft.RequirementCategory)
 [![Build Status](https://dev.azure.com/talha0113/Open%20Source/_apis/build/status/SharePoint-Proxy?branchName=master)](https://dev.azure.com/talha0113/Open%20Source/_build/latest?definitionId=44&branchName=master)
 
 ## SharePoint Proxy 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#198](https://dev.azure.com/talha0113/3504235c-4145-42ee-9d73-6f794f3258fd/_workitems/edit/198). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.